### PR TITLE
Added a check for errors in the puppet run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-puppet-last-run.rb: if the agent is disabled via lock file, display reason (if available)
 - Loosened dependency on sensu-plugin from `= 1.2.0` to `~> 1.2.0`
 - Updated Rubocop to 0.40, applied auto-correct
+- Added a check for errors in the puppet run
 
 ### Removed
 - Remove Ruby 1.9.3 support; add Ruby 2.2.0 and 2.3.0 support to test matrix.

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -69,6 +69,7 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
     begin
       summary = YAML.load_file(config[:summary_file])
       @last_run = summary['time']['last_run'].to_i
+      @failures = summary['events']['failures'].to_i
     rescue
       unknown "Could not process #{config[:summary_file]}"
     end
@@ -82,7 +83,11 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
       # fail silently
     end
 
-    if @now - @last_run > config[:crit_age]
+    if @failures > 0
+        @message += " with #{@failures} failures"
+    end
+
+    if @now - @last_run > config[:crit_age] || @failures > 0
       critical @message
     elsif @now - @last_run > config[:warn_age]
       warning @message

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -84,7 +84,7 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
     end
 
     if @failures > 0
-        @message += " with #{@failures} failures"
+      @message += " with #{@failures} failures"
     end
 
     if @now - @last_run > config[:crit_age] || @failures > 0


### PR DESCRIPTION
The check would return successful even if there were errors in the puppet run, so a new check was created to check for errors and display how many errors were present.
