### PR TITLE
Critical on bad summary

### DIFF
--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -68,6 +68,12 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
 
     begin
       summary = YAML.load_file(config[:summary_file])
+      unless summary['time']
+        critical "#{config[:summary_file]} is missing information about the last run timestamp"
+      else unless summary['events']
+        critical "#{config[:summary_file]} is missing information about the events"
+        end
+      end
       @last_run = summary['time']['last_run'].to_i
       @failures = summary['events']['failures'].to_i
     rescue


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#### General
- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [ ] RuboCop passes
- [ ] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose
#### Known Compatablity Issues

Make check-puppet-last-run.rb raise critical error, when last_run_summary.yaml
is missing some crucial information about the last timestamp or about the
events, which happened on the last Puppet run
