### PR TITLE
Critical on failures during summary file processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Chenged
+- check-puppet-last-run.rb: Added critical alrting on filures during summary file processing
 
 ## [1.0.0] - 2016-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Chenged
+### Changed
 - check-puppet-last-run.rb: Added critical alrting on filures during summary file processing
 
 ## [1.0.0] - 2016-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Changed
-- check-puppet-last-run.rb: Added critical alrting on filures during summary file processing
+- check-puppet-last-run.rb: Added critical alrting on failures during summary file processing
 
 ## [1.0.0] - 2016-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Changed
-- check-puppet-last-run.rb: Added critical alrting on failures during summary file processing
+- check-puppet-last-run.rb: Added critical alerting on failures during summary file processing
 
 ## [1.0.0] - 2016-06-21
 ### Changed

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -68,6 +68,12 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
 
     begin
       summary = YAML.load_file(config[:summary_file])
+      unless summary['time']
+        critical "#{config[:summary_file]} is missing information about the last run timestamp"
+      else unless summary['events']
+        critical "#{config[:summary_file]} is missing information about the events"
+        end
+      end
       @last_run = summary['time']['last_run'].to_i
       @failures = summary['events']['failures'].to_i
     rescue

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -68,14 +68,16 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
 
     begin
       summary = YAML.load_file(config[:summary_file])
-      unless summary['time']
+      if summary['time']
+        @last_run = summary['time']['last_run'].to_i
+      else
         critical "#{config[:summary_file]} is missing information about the last run timestamp"
-      else unless summary['events']
-        critical "#{config[:summary_file]} is missing information about the events"
-        end
       end
-      @last_run = summary['time']['last_run'].to_i
-      @failures = summary['events']['failures'].to_i
+      if summary['events']
+        @failures = summary['events']['failures'].to_i
+      else
+        critical "#{config[:summary_file]} is missing information about the events"
+      end
     rescue
       unknown "Could not process #{config[:summary_file]}"
     end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Make check-puppet-last-run.rb raise a critical error, when last_run_summary.yaml
is missing some crucial information about the last timestamp or about the
events, which happened on the last Puppet run. Such errors mean that Puppet has severe issues during it's run


#### Known Compatibility Issues

