### PR TITLE
Incorrect failure count hash key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
 - check-puppet-last-run.rb: Added critical alerting on failures during summary file processing
+- check-puppet-last-run.rb: Corrected failure count hash key
 
 ## [1.0.0] - 2016-06-21
 ### Changed

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -74,7 +74,7 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
         critical "#{config[:summary_file]} is missing information about the last run timestamp"
       end
       if summary['events']
-        @failures = summary['events']['failures'].to_i
+        @failures = summary['events']['failure'].to_i
       else
         critical "#{config[:summary_file]} is missing information about the events"
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Code references incorrect hash key ('failures') for failed resource count:

```
$ tail -4 last_run_summary.yaml 
events:
  failure: 1
  success: 6
  total: 7
```

#### Known Compatablity Issues

