### PR TITLE
Adding disabled warn crit levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Testing for Ruby 2.4.1
 
+# [Unreleased]
+### Added
+- Added options to allow for different age limits when the agent is disabled
+- Added a switch to use the new limits so as not to impact current functionality
+
 ## [1.2.0] - 2017-05-30
 ### Added
 - `check-puppet-last-run.rb`: Added option for reporting failed restarts (@antonidabek)


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
For our environment we have situations where puppet may disabled for an extended period of time as we perform some work so it was beneficial to have different thresholds for if a node is disabled. I have adjusted this check script to add three options, two for the thresholds and one on whether to follow those thresholds or not so that existing check definitions are not affected when its updated.

Testing Artifacts:
~$ /opt/sensu/embedded/bin/ruby /tmp/check-puppet-last-run.rb -s /var/lib/puppet/state/last_run_summary.yaml -a /var/lib/puppet/state/agent_disabled.lock -w 60 -c 120
PuppetLastRun CRITICAL: Puppet last run 28m 14s ago (disabled reason: Brad testing puppet alert) with 6 failures

~$ /opt/sensu/embedded/bin/ruby /tmp/check-puppet-last-run.rb -s /var/lib/puppet/state/last_run_summary.yaml -a /var/lib/puppet/state/agent_disabled.lock -w 60 -c 120 -W 1800 -C 86400
PuppetLastRun CRITICAL: Puppet last run 28m 15s ago (disabled reason: Brad testing puppet alert) with 6 failures

~$ /opt/sensu/embedded/bin/ruby /tmp/check-puppet-last-run.rb -s /var/lib/puppet/state/last_run_summary.yaml -a /var/lib/puppet/state/agent_disabled.lock -w 60 -c 120 -d -W 1800 -C 86400
PuppetLastRun OK: Puppet last run 29m 22s ago (disabled reason: Brad testing puppet alert) with 6 failures

~$ /opt/sensu/embedded/bin/ruby /tmp/check-puppet-last-run.rb -s /var/lib/puppet/state/last_run_summary.yaml -a /var/lib/puppet/state/agent_disabled.lock -w 60 -c 120 -d -W 1800 -C 86400
PuppetLastRun WARNING: Puppet last run 30m 6s ago (disabled reason: Brad testing puppet alert) with 6 failures

#### Known Compatibility Issues
None
