### PR TITLE
Add check for Puppet errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Chenged
+- check-puppet-last-run.rb: Added critical alrting on filures during summary file processing
 
 ## [1.0.0] - 2016-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Chenged
+### Changed
 - check-puppet-last-run.rb: Added critical alrting on filures during summary file processing
 
 ## [1.0.0] - 2016-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Changed
-- check-puppet-last-run.rb: Added critical alrting on filures during summary file processing
+- check-puppet-last-run.rb: Added critical alrting on failures during summary file processing
 
 ## [1.0.0] - 2016-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Testing for Ruby 2.4.1
+- `check-puppet-errors.rb`: Added check for Puppet failures (@grem11n)
+- `check-puppet-last-run.rb`: Added option for ignoring Puppet failure (@grem11n)
 
 ## [1.2.0] - 2017-05-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Changed
-- check-puppet-last-run.rb: Added critical alrting on failures during summary file processing
+- check-puppet-last-run.rb: Added critical alerting on failures during summary file processing
 
 ## [1.0.0] - 2016-06-21
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 **check-puppet-last-run.rb**
 **check-puppet-errors.rb**
 
+**check-puppet-errors.rb**
+
 ## Files
 
 * /bin/checkpuppet-last-run.rb

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@
 
 ## Functionality
 
-**check-puppet-last-run.rb**
-**check-puppet-errors.rb**
+### check-puppet-last-run.rb
+Validates Puppet last run. Alerts if last Puppet run was later than threshold or it has errors
 
-**check-puppet-errors.rb**
+### check-puppet-errors.rb
+Validates only Puppet run errors regardless of the execution time
 
 ## Files
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@
 ## Functionality
 
 **check-puppet-last-run.rb**
+**check-puppet-errors.rb**
 
 ## Files
 
 * /bin/checkpuppet-last-run.rb
 * /bin/metrics-puppet-run.rb
+* /bin/check-puppet-errors.rb
 
 ## Installation
 

--- a/bin/check-puppet-errors.rb
+++ b/bin/check-puppet-errors.rb
@@ -32,7 +32,7 @@ require 'yaml'
 require 'json'
 require 'time'
 
-class PuppetErros < Sensu::Plugin::Check::CLI
+class PuppetErrors < Sensu::Plugin::Check::CLI
   option :summary_file,
          short:       '-s PATH',
          long:        '--summary-file PATH',
@@ -66,8 +66,8 @@ class PuppetErros < Sensu::Plugin::Check::CLI
     begin
       disabled_message = JSON.parse(File.read(config[:agent_disabled_file]))['disabled_message']
       @message += " (disabled reason: #{disabled_message})"
-    rescue # rubocop:disable HandleExceptions
-      # fail silently
+    rescue => e
+      unknown "Could not get disabled message. Reason: #{e.message}"
     end
 
     if @failures > 0

--- a/bin/check-puppet-errors.rb
+++ b/bin/check-puppet-errors.rb
@@ -63,11 +63,13 @@ class PuppetErrors < Sensu::Plugin::Check::CLI
 
     @message = 'Puppet run'
 
-    begin
-      disabled_message = JSON.parse(File.read(config[:agent_disabled_file]))['disabled_message']
-      @message += " (disabled reason: #{disabled_message})"
-    rescue => e
-      unknown "Could not get disabled message. Reason: #{e.message}"
+    if File.exist?(config[:agent_disabled_file])
+      begin
+        disabled_message = JSON.parse(File.read(config[:agent_disabled_file]))['disabled_message']
+        @message += " (disabled reason: #{disabled_message})"
+      rescue => e
+        unknown "Could not get disabled message. Reason: #{e.message}"
+      end
     end
 
     if @failures > 0

--- a/bin/check-puppet-errors.rb
+++ b/bin/check-puppet-errors.rb
@@ -1,0 +1,68 @@
+#! /usr/bin/env ruby
+#
+# check-puppet-errors
+#
+# DESCRIPTION:
+#   Check if Puppet ran with errors
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   Critical if last run had errors
+#
+#   check-puppet-errors --summary-file /opt/puppetlabs/puppet/cache/state/last_run_summary.yaml
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2014 Sonian, Inc. and contributors. <support@sensuapp.org>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'yaml'
+require 'json'
+require 'time'
+
+class PuppetLastRun < Sensu::Plugin::Check::CLI
+  option :summary_file,
+         short:       '-s PATH',
+         long:        '--summary-file PATH',
+         default:     '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
+         description: 'Location of last_run_summary.yaml file'
+
+  def run
+    unless File.exist?(config[:summary_file])
+      unknown "File #{config[:summary_file]} not found"
+    end
+
+    begin
+      summary = YAML.load_file(config[:summary_file])
+      if summary['events']
+        @failures = summary['events']['failure'].to_i
+      else
+        critical "#{config[:summary_file]} is missing information about the events"
+      end
+    rescue
+      unknown "Could not process #{config[:summary_file]}"
+    end
+
+    @message = 'Puppet run'
+
+    if @failures > 0
+      @message += " had #{failures} failures"
+      critical @message
+    else
+      @message += ' was successful'
+      ok @message
+    end
+  end
+end

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -68,6 +68,12 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
 
     begin
       summary = YAML.load_file(config[:summary_file])
+      unless summary['time']
+        critical "#{config[:summary_file]} is missing information about the last run timestamp"
+      else unless summary['events']
+        critical "#{config[:summary_file]} is missing information about the events"
+        end
+      end
       @last_run = summary['time']['last_run'].to_i
       @failures = summary['events']['failures'].to_i
     rescue

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -68,14 +68,16 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
 
     begin
       summary = YAML.load_file(config[:summary_file])
-      unless summary['time']
+      if summary['time']
+        @last_run = summary['time']['last_run'].to_i
+      else
         critical "#{config[:summary_file]} is missing information about the last run timestamp"
-      else unless summary['events']
-        critical "#{config[:summary_file]} is missing information about the events"
-        end
       end
-      @last_run = summary['time']['last_run'].to_i
-      @failures = summary['events']['failures'].to_i
+      if summary['events']
+        @failures = summary['events']['failures'].to_i
+      else
+        critical "#{config[:summary_file]} is missing information about the events"
+      end
     rescue
       unknown "Could not process #{config[:summary_file]}"
     end

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -108,8 +108,8 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
     begin
       disabled_message = JSON.parse(File.read(config[:agent_disabled_file]))['disabled_message']
       @message += " (disabled reason: #{disabled_message})"
-    rescue # rubocop:disable HandleExceptions
-      # fail silently
+    rescue => e
+      unknown "Could not get disabled message. Reason: #{e.message}"
     end
 
     if @failures > 0

--- a/bin/check-puppet-last-run.rb
+++ b/bin/check-puppet-last-run.rb
@@ -105,11 +105,13 @@ class PuppetLastRun < Sensu::Plugin::Check::CLI
 
     @message = "Puppet last run #{formatted_duration(@now - @last_run)} ago"
 
-    begin
-      disabled_message = JSON.parse(File.read(config[:agent_disabled_file]))['disabled_message']
-      @message += " (disabled reason: #{disabled_message})"
-    rescue => e
-      unknown "Could not get disabled message. Reason: #{e.message}"
+    if File.exist?(config[:agent_disabled_file])
+      begin
+        disabled_message = JSON.parse(File.read(config[:agent_disabled_file]))['disabled_message']
+        @message += " (disabled reason: #{disabled_message})"
+      rescue => e
+        unknown "Could not get disabled message. Reason: #{e.message}"
+      end
     end
 
     if @failures > 0


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Several use cases:
* You want to check only if Puppet has errors during it's run regardless time of the execution
* You want to split alerting for Puppet issues e.g. send Sensu alert to one subscription if Puppet has errors, and to another subscription if it ran a while ago, but without errors.

#### Known Compatibility Issues
Tested on Ubuntu 16.04. Should work on other Linux distributions as well
