### PR TITLE
checking for errors in last_run_report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- `check-puppet-errors.rb` will now also check for errors in the `last_run_report.yaml` (@elfranne)
 
 ## [3.0.0] - 2020-03-24
 ### Breaking Change

--- a/bin/check-puppet-errors.rb
+++ b/bin/check-puppet-errors.rb
@@ -74,11 +74,11 @@ class PuppetErrors < Sensu::Plugin::Check::CLI
     end
 
     begin
-      File.foreach(config[:report_file]).take(13).each { |line| 
-        if line.chomp.eql? 'status: failed'
+      %["sudo /usr/bin/head -n 13 #{config[:report_file]}"].split('\n').each { |line| 
+        if line.eql? 'status: failed'
           critical 'Last Puppet run reports status: failed'
         end
-        if line.chomp.eql? 'transaction_completed: false'
+        if line.eql? 'transaction_completed: false'
           critical 'Last Puppet run reports transaction_completed: false'
         end
       }

--- a/bin/check-puppet-errors.rb
+++ b/bin/check-puppet-errors.rb
@@ -47,10 +47,19 @@ class PuppetErrors < Sensu::Plugin::Check::CLI
          long: '--agent-disabled-file PATH',
          default: SensuPluginsPuppet::AGENT_DISABLED_FILE,
          description: 'Path to agent disabled lock file'
-
+         
+  option :report_file,
+         short: '-r PATH',
+         long: '--report-file PATH',
+         default: SensuPluginsPuppet::REPORT_FILE,
+         description: 'Location of last_run_report.yaml file'
+  
   def run
     unless File.exist?(config[:summary_file])
       unknown "File #{config[:summary_file]} not found"
+    end
+    unless File.exist?(config[:report_file])
+      unknown "File #{config[:report_file]} not found"
     end
 
     begin
@@ -62,6 +71,19 @@ class PuppetErrors < Sensu::Plugin::Check::CLI
       end
     rescue StandardError
       unknown "Could not process #{config[:summary_file]}"
+    end
+
+    begin
+      File.foreach(config[:report_file]).take(13).each { |line| 
+        if line.chomp.eql? 'status: failed'
+          critical 'Last Puppet run reports status: failed'
+        end
+        if line.chomp.eql? 'transaction_completed: false'
+          critical 'Last Puppet run reports transaction_completed: false'
+        end
+      }
+    rescue StandardError
+      unknown "Could not process #{config[:report_file]}"
     end
 
     @message = 'Puppet run'

--- a/lib/sensu-plugins-puppet.rb
+++ b/lib/sensu-plugins-puppet.rb
@@ -4,5 +4,6 @@ require 'sensu-plugins-puppet/version'
 
 module SensuPluginsPuppet
   SUMMARY_FILE        = "#{Gem.win_platform? ? 'C:/ProgramData/PuppetLabs' : '/opt/puppetlabs'}/puppet/cache/state/last_run_summary.yaml".freeze
+  REPORT_FILE         = "#{Gem.win_platform? ? 'C:/ProgramData/PuppetLabs' : '/opt/puppetlabs'}/puppet/cache/state/last_run_report.yaml".freeze
   AGENT_DISABLED_FILE = "#{Gem.win_platform? ? 'C:/ProgramData/PuppetLabs' : '/opt/puppetlabs'}/puppet/cache/state/agent_disabled.lock".freeze
 end


### PR DESCRIPTION
#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
Errors like this:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Could not find resource 'Exec[systemctl-daemon-reload]' for relationship on 'Service[oxidized]' on node node.domain.com
```
do not appear in the summary file because it never manage to get the catalog, see https://tickets.puppetlabs.com/browse/PUP-9396 and https://tickets.puppetlabs.com/browse/PUP-2089

But they appear in `last_run_report.yaml`:

```log
sudo head -n 13 /opt/puppetlabs/puppet/cache/state/last_run_report.yaml
--- !ruby/object:Puppet::Transaction::Report
host: node.domain.com
time: '2021-07-09T11:42:36.256429184+00:00'
configuration_version:
transaction_uuid: [long string]
report_format: 11
puppet_version: 6.23.0
status: failed
transaction_completed: false
noop: false
noop_pending: false
environment: production
logs:

```

The check is not using the YAML library (loads the entire file into memory) because the report file can be quite big. So only the 13 first line are used.

#### Known Compatibility Issues
None